### PR TITLE
Massive Controller Code Cleanup

### DIFF
--- a/app/controllers/fullcalendar_engine/events_controller.rb
+++ b/app/controllers/fullcalendar_engine/events_controller.rb
@@ -1,18 +1,18 @@
-require_dependency "fullcalendar_engine/application_controller"
+require_dependency 'fullcalendar_engine/application_controller'
 
 module FullcalendarEngine
   class EventsController < ApplicationController
 
-    layout FullcalendarEngine::Configuration['layout'] || "application"
+    layout FullcalendarEngine::Configuration['layout'] || 'application'
 
-    before_filter :load_event, :only => [:edit, :update, :destroy, :move, :resize]
-    before_filter :determine_event_type, :only => :create
+    before_filter :load_event, only: [:edit, :update, :destroy, :move, :resize]
+    before_filter :determine_event_type, only: :create
 
     def create
       if @event.save
-        render :nothing => true
+        render nothing: true
       else
-        render :text => @event.errors.full_messages.to_sentence, :status => 422
+        render text: @event.errors.full_messages.to_sentence, status: 422
       end
     end
 
@@ -23,84 +23,98 @@ module FullcalendarEngine
     end
 
     def get_events
-      @events = Event.where("starttime >= '#{Time.at(params['start'].to_i).to_formatted_s(:db)}' and endtime <= '#{Time.at(params['end'].to_i).to_formatted_s(:db)}'")
+      @events = Event.where('starttime  >= :start_time and 
+                            endtime     <= :end_time',
+                            start_time: Time.at(params['start'].to_i).to_formatted_s(:db),
+                            end_time:   Time.at(params['end'].to_i).to_formatted_s(:db))
       events = []
       @events.each do |event|
-        events << {:id => event.id, :title => event.title, :description => event.description || "Some cool description here...", :start => "#{event.starttime.iso8601}", :end => "#{event.endtime.iso8601}", :allDay => event.all_day, :recurring => (event.event_series_id)? true: false}
+        events << { id: event.id,
+                    title: event.title,
+                    description: event.description || '', 
+                    start: event.starttime.iso8601,
+                    end: event.endtime.iso8601,
+                    allDay: event.all_day,
+                    recurring: (event.event_series_id) ? true : false }
       end
-      render :json => events.to_json
+      render json: events.to_json
     end
 
     def move
       if @event
-        @event.starttime = (params[:minute_delta].to_i).minutes.from_now((params[:day_delta].to_i).days.from_now(@event.starttime))
-        @event.endtime = (params[:minute_delta].to_i).minutes.from_now((params[:day_delta].to_i).days.from_now(@event.endtime))
-        @event.all_day = params[:all_day]
+        @event.starttime = make_time_from_minute_and_day_delta(@event.starttime)
+        @event.endtime   = make_time_from_minute_and_day_delta(@event.endtime)
+        @event.all_day   = params[:all_day]
         @event.save
       end
-      render :nothing => true
+      render nothing: true
     end
 
     def resize
       if @event
-        @event.endtime = (params[:minute_delta].to_i).minutes.from_now((params[:day_delta].to_i).days.from_now(@event.endtime))
+        @event.endtime = make_time_from_minute_and_day_delta(@event.endtime)
         @event.save
       end    
-      render :nothing => true
+      render nothing: true
     end
 
     def edit
-      render :json => { :form => render_to_string(:partial => 'edit_form') } 
+      render json: { form: render_to_string(partial: 'edit_form') } 
     end
 
     def update
       case params[:event][:commit_button]
-      when "Update All Occurrence"
-        @events = @event.event_series.events #.find(:all, :conditions => ["starttime > '#{@event.starttime.to_formatted_s(:db)}' "])
+      when 'Update All Occurrence'
+        @events = @event.event_series.events
         @event.update_events(@events, event_params)
-      when "Update All Following Occurrence"
-        @events = @event.event_series.events.find(:all, :conditions => ["starttime > '#{@event.starttime.to_formatted_s(:db)}' "])
+      when 'Update All Following Occurrence'
+        @events = @event.event_series.events.where('starttime > :start_time', 
+                                                   start_time: @event.starttime.to_formatted_s(:db)).to_a
         @event.update_events(@events, event_params)
       else
         @event.attributes = event_params
         @event.save
       end
-      render :nothing => true
+      render nothing: true
     end
 
     def destroy
       case params[:delete_all]
-      when "true"
+      when 'true'
         @event.event_series.destroy
-      when "future"
-        @events = @event.event_series.events.find(:all, :conditions => ["starttime > '#{@event.starttime.to_formatted_s(:db)}' "])
-        @event.event_series.events.delete(@events)  
+      when 'future'
+        @events = @event.event_series.events.where('starttime > :start_time',
+                                                   start_time: @event.starttime.to_formatted_s(:db)).to_a
+        @event.event_series.events.delete(@events)
       else
         @event.destroy
       end
-      render :nothing => true
+      render nothing: true
     end
 
     private
 
-      def load_event
-        @event = Event.where(:id => params[:id]).first
-        unless @event
-          render :json => {:message => "Event Not Found.."}, :status => 404 and return
-        end
+    def load_event
+      @event = Event.where(:id => params[:id]).first
+      unless @event
+        render json: { message: "Event Not Found.."}, status: 404 and return
       end
+    end
 
-      def event_params
-        params.require(:event).permit('title', 'description', 'starttime(1i)', 'starttime(2i)', 'starttime(3i)', 'starttime(4i)', 'starttime(5i)', 'endtime(1i)', 'endtime(2i)', 'endtime(3i)', 'endtime(4i)', 'endtime(5i)', 'all_day', 'period', 'frequency', 'commit_button')
+    def event_params
+      params.require(:event).permit('title', 'description', 'starttime', 'endtime', 'all_day', 'period', 'frequency', 'commit_button')
+    end
+
+    def determine_event_type
+      if params[:event][:period] == "Does not repeat"
+        @event = Event.new(event_params)
+      else
+        @event = EventSeries.new(event_params)
       end
+    end
 
-      def determine_event_type
-        if params[:event][:period] == "Does not repeat"
-          @event = Event.new(event_params)
-        else
-          @event = EventSeries.new(event_params)
-        end
-      end
-
+    def make_time_from_minute_and_day_delta(event_time)
+      params[:minute_delta].to_i.minutes.from_now((params[:day_delta].to_i).days.from_now(event_time))
+    end
   end
 end

--- a/app/views/fullcalendar_engine/events/_edit_form.html.erb
+++ b/app/views/fullcalendar_engine/events/_edit_form.html.erb
@@ -24,7 +24,6 @@
   <%=f.check_box :all_day %>
 </p>
 
-<%=f.hidden_field :id, :value => @event.id%>
 <%=f.hidden_field :commit_button, :value => ""%>
 <p>
   <%if @event.event_series -%>

--- a/app/views/fullcalendar_engine/events/_form.html.erb
+++ b/app/views/fullcalendar_engine/events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @event ||= FullcalendarEngine::Event.new, :html => { :id => 'event_form' } do |f| %>
+<%= form_for @event ||= FullcalendarEngine::Event.new, :html => { id: 'event_form' } do |f| %>
 <p>
   <%=f.label :title %>
   <br/>
@@ -25,14 +25,13 @@
 </p>
 <p>
   <%=f.label :period, "Repeats" %>
-  <%=f.select :period, FullcalendarEngine::Event::REPEATS.values,{}, :onchange => "FullcalendarEngine.Events.showPeriodAndFrequency(this.value);" %>
+  <%=f.select :period, FullcalendarEngine::Event::REPEATS.values, {}, onchange: "FullcalendarEngine.Events.showPeriodAndFrequency(this.value);" %>
 </p>
 <p id = "frequency" style = "display:none;">
   <%=f.label :frequency, "Repeat every" %>
   <%=f.select :frequency, (1..30).to_a %> <span id = "period"></span>
 </p>
-<%=f.hidden_field :id, :value => @event.id %>
 <p>
-  <%=f.submit 'Create' %> <span id = "creating_events" class="spinner" style = "display:none;">Creating, Please wait...</span>
+  <%=f.submit %> <span id = "creating_events" class="spinner" style = "display:none;">Creating, Please wait...</span>
 </p>
 <%end %>


### PR DESCRIPTION
- Remove the occurrences of #find with #where.to_a so as to avoid the exception generation.
- Use the new Ruby syntax
- Avoid nested parameters in the controller actions
- Refactor some code so as to reduce the clutter in the file
- Remove hidden field for :id as they are no longer needed. This will also help in case of strict strong_parameters
- Remove additional parameters for datetime_select in starttime and endtime from strong_parameters as mentioned in the [PR](https://github.com/rails/strong_parameters/pull/39) 
