### PR TITLE
Correct query fetch

### DIFF
--- a/app/controllers/fullcalendar_engine/events_controller.rb
+++ b/app/controllers/fullcalendar_engine/events_controller.rb
@@ -22,7 +22,7 @@ module FullcalendarEngine
       end
     end
 
-    def get_events
+    def index
       start_time = Time.at(params[:start].to_i).to_formatted_s(:db)
       end_time   = Time.at(params[:end].to_i).to_formatted_s(:db)
 

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -15,4 +15,4 @@ FullcalendarEngine::Configuration = {
   'timeFormat'  => "h:mm t{ - h:mm t}"
 }
 FullcalendarEngine::Configuration.merge!(config)
-FullcalendarEngine::Configuration['events'] = "#{FullcalendarEngine::Configuration['mount_path']}/events/get_events"
+FullcalendarEngine::Configuration['events'] = "#{FullcalendarEngine::Configuration['mount_path']}/events"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,9 @@
 FullcalendarEngine::Engine.routes.draw do
-  root :to => 'events#index'
   resources :events do 
-    collection do 
-      get :get_events
-    end
     member do
       post :move
       post :resize
     end
   end
+  root :to => 'events#index'
 end


### PR DESCRIPTION
- Fix the query criteria for the fetching of event in the given time slot.
- Rename get_events action to index to make it more in line with RESTful ideology

Fixes #8 
