### PR TITLE
Fixes validation problem

### DIFF
--- a/app/models/fullcalendar_engine/event.rb
+++ b/app/models/fullcalendar_engine/event.rb
@@ -3,7 +3,7 @@ module FullcalendarEngine
 
     attr_accessor :period, :frequency, :commit_button
 
-    validates :title, :description, :presence => true
+    validates :title, :description, :starttime, :endtime, :presence => true
     validate :validate_timings
 
     belongs_to :event_series
@@ -17,8 +17,10 @@ module FullcalendarEngine
     }
     
     def validate_timings
-      if (starttime >= endtime) and !all_day
-        errors[:base] << "Start Time must be less than End Time"
+      if !starttime.nil? and !endtime.nil?
+        if (starttime >= endtime) and !all_day
+          errors[:base] << "Start Time must be less than End Time"
+        end
       end
     end
 

--- a/app/models/fullcalendar_engine/event.rb
+++ b/app/models/fullcalendar_engine/event.rb
@@ -17,7 +17,7 @@ module FullcalendarEngine
     }
     
     def validate_timings
-      if !starttime.nil? and !endtime.nil?
+      if starttime.present? and endtime.present?
         if (starttime >= endtime) and !all_day
           errors[:base] << "Start Time must be less than End Time"
         end


### PR DESCRIPTION
Calling `FullcalendarEngine::Event.new.valid?` resulted in ``NoMethodError: undefined method `>=' for nil:NilClass`` on ``app/models/fullcalendar_engine/event.rb:21:in `validate_timings'``

Starttime and endtime can be nil and `>=` is obviously not available on nil. Instead, `validate_timings` now verifies that both `starttime` and `endtime` are set before calling `>=`.

Presence validations for `starttime` and `endtimes` are also added, so the model will still be invalid even though `>=` is not called in `validate_timings`.